### PR TITLE
Use Key::Equal method to know if two nodes are equal

### DIFF
--- a/src/kbucket.go
+++ b/src/kbucket.go
@@ -21,7 +21,8 @@ func (kB *kademliaKBucket) Update(c Kademlia) {
 	first := kB.start
 	var prev *linkedList = nil
 	for true {
-		if first.value.GetNodeId() == c.GetNodeId() {
+		equal, _ := first.value.GetNodeId().Equal(c.GetNodeId())
+		if equal {
 			kB.last.next = first
 			kB.last = first
 			if prev == nil {


### PR DESCRIPTION
Change older approach of compare reference and use Key::Equal method for compare keys in kademliaKbucket::Update method